### PR TITLE
#12 - Initial paramaterization of values 4 docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Nightscout as Code 
+# Nightscout as Code for AWS
 
-**Note: this is a work-in-progress and should not be used in production until this notice is removed**
+**Note: this is in an early testing phase and should be used with caution.
 
 This project makes it *relatively* straightforward to deploy [Nightscout CGM](https://github.com/nightscout/cgm-remote-monitor), on almost any platform, now that Heroku no longer offers a free tier. At the moment only AWS deployments have been completed, but Azure & GCP are expected in due time.
 
@@ -18,7 +18,7 @@ Taking the codified approach over the GUI (clicky) approach has some benefits:
 
 ## Approach
 
-This project ***does not** provide a free alternative to Heroku*. Rather it takes the position that these files can be easily run anywhere for very low cost. 
+This project ***does not** provide a free alternative to Heroku*. Rather it takes the position that these files can be more easily run anywhere for very low cost. 
 
 ## What's in the box
 

--- a/main.tf
+++ b/main.tf
@@ -59,4 +59,10 @@ module "nightscout" {
   features = var.nightscout_features
   api_key  = var.nightscout_api_key
   storage  = var.storage
+
+  # Additional configuration options
+  nightscout_image = var.nightscout_image
+  nightscout_image_tag = var.nightscout_image_tag
+  mongo_image = var.mongo_image
+  mongo_image_tag = var.mongo_image_tag
 }

--- a/nightscout/docker-compose.yml
+++ b/nightscout/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     restart: unless-stopped
 
   mongo:
-    image: mongo:4.4
+    image: ${MONGO_IMAGE}:${MONGO_IMAGE_TAG}
     networks:
       - caddy
     volumes:
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
 
   nightscout:
-    image: nightscout/cgm-remote-monitor:latest
+    image: ${NIGHTSCOUT_IMAGE}:${NIGHTSCOUT_IMAGE_TAG}
     networks:
       - caddy
     labels:

--- a/nightscout/nightscout-userdata.sh
+++ b/nightscout/nightscout-userdata.sh
@@ -17,7 +17,7 @@ echo 'export AWS_DEFAULT_REGION="${region}"' >> /home/ubuntu/.env
 
 # AWS Docker Composed Advanced Options
 echo 'export MONGO_IMAGE="${mongo_image}"' >> /home/ubuntu/.env
-echo 'export MONGO_IMAGE_TAG="${mongo_image_tag"' >> /home/ubuntu/.env
+echo 'export MONGO_IMAGE_TAG="${mongo_image_tag}"' >> /home/ubuntu/.env
 echo 'export NIGHTSCOUT_IMAGE="${nightscout_image}"' >> /home/ubuntu/.env
 echo 'export NIGHTSCOUT_IMAGE_TAG="${nighscout_image_tag}"' >> /home/ubuntu/.env
 

--- a/nightscout/nightscout-userdata.sh
+++ b/nightscout/nightscout-userdata.sh
@@ -15,6 +15,12 @@ echo 'export AWS_ACCESS_KEY_ID="${access_key}"' >> /home/ubuntu/.env
 echo 'export AWS_SECRET_ACCESS_KEY="${secret_key}"' >> /home/ubuntu/.env
 echo 'export AWS_DEFAULT_REGION="${region}"' >> /home/ubuntu/.env
 
+# AWS Docker Composed Advanced Options
+echo 'export MONGO_IMAGE="${mongo_image}"' >> /home/ubuntu/.env
+echo 'export MONGO_IMAGE_TAG="${mongo_image_tag"' >> /home/ubuntu/.env
+echo 'export NIGHTSCOUT_IMAGE="${nightscout_image}"' >> /home/ubuntu/.env
+echo 'export NIGHTSCOUT_IMAGE_TAG="${nighscout_image_tag}"' >> /home/ubuntu/.env
+
 cat /home/ubuntu/.env >> /home/ubuntu/.profile
 
 # echo "Updating the system and installing Docker CE"

--- a/nightscout/nightscout-userdata.sh
+++ b/nightscout/nightscout-userdata.sh
@@ -19,7 +19,7 @@ echo 'export AWS_DEFAULT_REGION="${region}"' >> /home/ubuntu/.env
 echo 'export MONGO_IMAGE="${mongo_image}"' >> /home/ubuntu/.env
 echo 'export MONGO_IMAGE_TAG="${mongo_image_tag}"' >> /home/ubuntu/.env
 echo 'export NIGHTSCOUT_IMAGE="${nightscout_image}"' >> /home/ubuntu/.env
-echo 'export NIGHTSCOUT_IMAGE_TAG="${nighscout_image_tag}"' >> /home/ubuntu/.env
+echo 'export NIGHTSCOUT_IMAGE_TAG="${nightscout_image_tag}"' >> /home/ubuntu/.env
 
 cat /home/ubuntu/.env >> /home/ubuntu/.profile
 

--- a/nightscout/nightscout_instance.tf
+++ b/nightscout/nightscout_instance.tf
@@ -40,6 +40,10 @@ resource "aws_instance" "nightscout" {
     access_key = var.access_key
     secret_key = var.secret_key
     region     = var.region
+    nightscout_image = var.nightscout_image
+    nightscout_image_tag = var.nightscout_image_tag
+    mongo_image = var.mongo_image
+    mongo_image_tag = var.mongo_image_tag
   })
 
   connection {

--- a/nightscout/variables.tf
+++ b/nightscout/variables.tf
@@ -66,3 +66,23 @@ variable "storage" {
   type        = number
   description = "The amount of storage for your Nightscout data in GB."
 }
+
+variable "nightscout_image" {
+  type = string
+  description = "The Docker image used for Nightscout. Offers the opportunity to customize which image is being run. Defaults to the official Nightscout image."
+}
+
+variable "nightscout_image_tag" {
+  type = string
+  description = "The tag used to specify which image version of nightscout is being run. Defaults to latest."
+} 
+
+variable "mongo_image" {
+  type = string
+  description = "The Docker image used for Mongo. Offers the opportunity to customize which mongo docker image is being run. Defaults to the offical mongo docker image."
+}
+
+variable "mongo_image_tag" {
+  type = string
+  description = "The tag used to specify which image version of mongo is being run. Defaults to 4.4."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,33 @@ variable "aws_secret_key" {
   description = "Your AWS secret access key."
 }
 
+##### 
+# Additional configuration option variables
+####
+variable "nightscout_image" {
+  type = string
+  default = "nightscout/cgm-remote-monitor"
+  description = "The Docker image used for Nightscout. Offers the opportunity to customize which image is being run. Defaults to the official Nightscout image."
+}
+
+variable "nightscout_image_tag" {
+  type = string
+  default = "latest"
+  description = "The tag used to specify which image version of nightscout is being run. Defaults to latest."
+} 
+
+variable "mongo_image" {
+  type = string
+  default = "mongo"
+  description = "The Docker image used for Mongo. Offers the opportunity to customize which mongo docker image is being run. Defaults to the offical mongo docker image."
+}
+
+variable "mongo_image_tag" {
+  type = string
+  default = "4.4"
+  description = "The tag used to specify which image version of mongo is being run. Defaults to 4.4."
+}
+
 # Choose a region for your deployment
 # The Default Region is for the East Coast of the US
 #


### PR DESCRIPTION
Resolves #12 

This PR modifies the configuration such that users can optionally define a value for both the docker image and tag used for Nightscout and Mongo. 

In this PR the defaults are (`image`:`tag`):
Nightscout: `nightscout\cgm-remote-monitor`:`latest`
Mongo: `mongo`:`4.4`

The variable keys are:
Nightscout: `nightscout_image`:`nightscout_image_tag`
Mongo: `mongo_image`:`mongo_image_tag`